### PR TITLE
Missing field in MotorRPM.msg

### DIFF
--- a/msg/MotorRPM.msg
+++ b/msg/MotorRPM.msg
@@ -1,2 +1,3 @@
 Header header
+time[] sample_stamp
 float32[] rpm


### PR DESCRIPTION
Dear Blackbird Team

Your definition of the message `MotorRPM.msg` is inconsistent with the one in the ROS bags.
It is missing the field `time[] sample_stamp`.

I fixed it in this pull request.

Cheers